### PR TITLE
Add support for LLVM4/5/6/7 @Containers branch

### DIFF
--- a/skeleton/Skeleton.cpp
+++ b/skeleton/Skeleton.cpp
@@ -15,15 +15,15 @@ namespace {
 
       errs() << "Function body:\n";
       //F.dump(); Out-of-Date: no more dump support in modern llvm unless you enable it at compile time.
-      F->print(llvm::errs(), nullptr);
+      F.print(llvm::errs());
 
       for (auto &B : F) {
         errs() << "Basic block:\n";
-        B->print(llvm::errs(), nullptr);
+        B.print(llvm::errs(), true);
 
         for (auto &I : B) {
           errs() << "Instruction: ";
-          I->print(llvm::errs(), nullptr);
+          I.print(llvm::errs(), true);
         }
       }
 

--- a/skeleton/Skeleton.cpp
+++ b/skeleton/Skeleton.cpp
@@ -14,15 +14,16 @@ namespace {
       errs() << "In a function called " << F.getName() << "!\n";
 
       errs() << "Function body:\n";
-      F.dump();
+      //F.dump(); Out-of-Date: no more dump support in modern llvm unless you enable it at compile time.
+      F->print(llvm::errs(), nullptr);
 
       for (auto &B : F) {
         errs() << "Basic block:\n";
-        B.dump();
+        B->print(llvm::errs(), nullptr);
 
         for (auto &I : B) {
           errs() << "Instruction: ";
-          I.dump();
+          I->print(llvm::errs(), nullptr);
         }
       }
 


### PR DESCRIPTION
Fix Issue: [Issue 17](https://github.com/sampsyo/llvm-pass-skeleton/issues/17)

Root cause of the issue is that newer version of LLVM doesn't have a `dump` function. So we can use `print` instead.

Tested on LLVM 5/6/7.