### PR TITLE
Add `-Xclang -disable-O0-optnone` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ Build:
 
 Run:
 
-    $ clang -S -emit-llvm foo.c
+    $ clang -S -emit-llvm -Xclang -disable-O0-optnone foo.c
     $ opt -load build/skeleton/libSkeletonPass.* -skeleton -S foo.ll
+    
+The `-Xclang -disable-O0-optnone` flag ensures that Clang will allow later optimizations even when initially compiling without any. 


### PR DESCRIPTION
Not adding `-Xclang -disable-O0-optnone` to our initial clang invocation made us very sad, because none of our optimizations would run. As Drew/Adrian discussed in Slack, this flag is probably the right way around that pitfall