### PR TITLE
Use opt for legacy PM for LLVM14.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
-
-set(CMAKE_CXX_STANDARD 14)
+project(SkeletonPass)
 
 find_package(LLVM REQUIRED CONFIG)
+
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
 add_definitions(${LLVM_DEFINITIONS})
 include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(SkeletonPass)
 set(CMAKE_CXX_STANDARD 14)
 
 find_package(LLVM REQUIRED CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
+
 project(SkeletonPass)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(LLVM REQUIRED CONFIG)
-
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
 add_definitions(${LLVM_DEFINITIONS})
 include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # llvm-pass-skeleton
 
-A completely useless LLVM pass.
+A completely useless LLVM pass written for LLVM-14.0+.
 
 Build:
 
@@ -13,4 +13,5 @@ Build:
 
 Run:
 
-    $ clang -Xclang -load -Xclang build/skeleton/libSkeletonPass.* something.c
+    $ clang -O3 -emit-llvm something.c -c -o something.bc
+    $ opt -load build/skeleton/libSkeletonPass.so -enable-new-pm=0 -skeleton -disable-output something.bc

--- a/README.md
+++ b/README.md
@@ -13,5 +13,4 @@ Build:
 
 Run:
 
-    $ clang -O3 -emit-llvm something.c -c -o something.bc
-    $ opt -load build/skeleton/libSkeletonPass.so -enable-new-pm=0 -skeleton -disable-output something.bc
+    $ clang -Xclang -load -flegacy-pass-manager -Xclang build/skeleton/libSkeletonPass.* something.bc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # llvm-pass-skeleton
 
-A completely useless LLVM pass written for LLVM-14.0+.
+A completely useless LLVM pass written for LLVM-14.0 onwards.
 
 Build:
 
@@ -13,4 +13,4 @@ Build:
 
 Run:
 
-    $ clang -Xclang -load -flegacy-pass-manager -Xclang build/skeleton/libSkeletonPass.* something.bc
+    $ clang -Xclang -load -flegacy-pass-manager -Xclang build/skeleton/libSkeletonPass.* something.c

--- a/skeleton/Skeleton.cpp
+++ b/skeleton/Skeleton.cpp
@@ -10,7 +10,7 @@ namespace {
     static char ID;
     SkeletonPass() : FunctionPass(ID) {}
 
-    bool runOnFunction(Function &F) override {
+    virtual bool runOnFunction(Function &F) {
       errs() << "In a function called " << F.getName() << "!\n";
 
       errs() << "Function body:\n";

--- a/skeleton/Skeleton.cpp
+++ b/skeleton/Skeleton.cpp
@@ -2,8 +2,6 @@
 #include "llvm/IR/Function.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/IR/LegacyPassManager.h"
-#include "llvm/Passes/PassBuilder.h"
-#include "llvm/Passes/PassPlugin.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 using namespace llvm;
 
@@ -35,18 +33,14 @@ namespace {
   };
 }
 
-/* Register Legacy Pass */
 char SkeletonPass::ID = 0;
 
-/* Make the pass callable using `-skeleton`, as suggested by LLVM docs */
-static RegisterPass<SkeletonPass> 
-RegisterMyPass("skeleton", "Skeleton Pass",
-      false, // This pass doesn't modify the CFG => true
-      false // This pass is not a pure analysis pass => false
-      );
-
-static llvm::RegisterStandardPasses Y(
-    llvm::PassManagerBuilder::EP_EarlyAsPossible,
-    [](const llvm::PassManagerBuilder &Builder,
-       llvm::legacy::PassManagerBase &PM) { PM.add(new SkeletonPass()); });
-
+// Automatically enable the pass.
+// http://adriansampson.net/blog/clangpass.html
+static void registerSkeletonPass(const PassManagerBuilder &,
+                         legacy::PassManagerBase &PM) {
+  PM.add(new SkeletonPass());
+}
+static RegisterStandardPasses
+  RegisterMyPass(PassManagerBuilder::EP_EarlyAsPossible,
+                 registerSkeletonPass);


### PR DESCRIPTION
Hi @sampsyo, this is a PR for users to use the legacy PM for [LLVM14.0 onwards](https://github.com/AFLplusplus/AFLplusplus/issues/1100). It adds the following things

- Use `opt` for running the pass on LLVM bitcode, as the latest `clang` versions use the new PM by default.
- Pass name through `skeleton` flag name to `opt`

It might be best to put this in a new branch if new users use your tutorials as a guide for newer LLVM versions. Thanks for making the lectures public - have helped me greatly :)! 